### PR TITLE
Fix/matplotlib cartopy compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,183 @@
+# ==================================
+# SHOWCast .gitignore
+# ==================================
+
+# ========== DATA & DOWNLOADS ==========
+# Downloaded satellite data (very large!)
+v2.5.2/Cloud/Downloads/
+**/Downloads/
+
+# Output images and processed data
+v2.5.2/Output/
+**/Output/
+
+# ========== LOGS ==========
+# All log files
+v2.5.2/Cloud/Logs/*.txt
+v2.5.2/Cloud/Logs/*.log
+v2.5.2/Logs/*.txt
+v2.5.2/Logs/*.log
+**/Logs/*.txt
+**/Logs/*.log
+
+# ========== TEMPORARY FILES ==========
+# Temporary download directory
+v2.5.2/Cloud/Scripts/tmp/
+**/tmp/
+**/temp/
+*.tmp
+
+# ========== PYTHON ==========
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Unit test / coverage
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# ========== CONDA/MINICONDA ==========
+# Conda environment (very large!)
+v2.5.2/Miniconda3/
+**/Miniconda3/
+**/miniconda3/
+**/anaconda3/
+
+# ========== IDE & EDITORS ==========
+# VS Code
+.vscode/
+*.code-workspace
+
+# PyCharm
+.idea/
+
+# Sublime Text
+*.sublime-project
+*.sublime-workspace
+
+# Vim
+*.swp
+*.swo
+*~
+
+# Emacs
+*~
+\#*\#
+.\#*
+
+# ========== OS SPECIFIC ==========
+# MacOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Windows
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+*.stackdump
+[Dd]esktop.ini
+$RECYCLE.BIN/
+*.lnk
+
+# Linux
+.directory
+.Trash-*
+
+# ========== SCIENTIFIC DATA FILES ==========
+# NetCDF files (can be large)
+*.nc
+*.nc4
+
+# GRIB files
+*.grb
+*.grb2
+*.grib
+*.grib2
+
+# HDF files
+*.hdf
+*.h5
+*.hdf5
+
+# ========== IMAGE FILES (Optional - comment out if you want to track them) ==========
+# Uncomment if you don't want to track generated images
+# *.png
+# *.jpg
+# *.jpeg
+# *.gif
+# *.bmp
+# *.tiff
+
+# ========== ARCHIVES & COMPRESSED ==========
+*.zip
+*.tar
+*.tar.gz
+*.tgz
+*.rar
+*.7z
+
+# ========== CONFIG FILES (be careful!) ==========
+# Uncomment specific configs you don't want to track
+# config_local.py
+# *_local.py
+# secrets.py
+
+# ========== CUSTOM IGNORES ==========
+# Add project-specific ignores below
+

--- a/v2.5.2/Scripts/html_update.py
+++ b/v2.5.2/Scripts/html_update.py
@@ -89,7 +89,7 @@ def update(satellite, product, nfiles, outdir, vis_dir):
     diff_files = max_files - num_files
     
     # If there are less files than the maximum HTML animation files, repeat the last one "x" times
-    if diff_files > 0:
+    if diff_files > 0 and num_files > 0:
         for i in range(diff_files):
             dst = out_dir + rename_id + str(num_files + i + 1) + '.webp'       
             copyfile(files[-1], dst)
@@ -102,11 +102,12 @@ def update(satellite, product, nfiles, outdir, vis_dir):
         
     # Create the thumbnail of the last file
     thumb_dir = vis_dir + 'QuickLooks//' + rename_id + 'quicklook.webp'
-    copyfile(files[-1], dst)
-    im = Image.open(files[-1])
-    size = (1024,1024)
-    im = im.resize(size)
-    im.save(thumb_dir)
+    if num_files > 0:
+        copyfile(files[-1], thumb_dir)
+        im = Image.open(files[-1])
+        size = (1024,1024)
+        im = im.resize(size)
+        im.save(thumb_dir)
     
     #print('Total processing time:', round((t.time() - start),2), 'seconds.') 
 

--- a/v2.5.2/Scripts/process_flood_mapping.py
+++ b/v2.5.2/Scripts/process_flood_mapping.py
@@ -318,7 +318,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)

--- a/v2.5.2/Scripts/process_g19_24hrgb_fdk.py
+++ b/v2.5.2/Scripts/process_g19_24hrgb_fdk.py
@@ -330,7 +330,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=5)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_24hrgb_sec.py
+++ b/v2.5.2/Scripts/process_g19_24hrgb_sec.py
@@ -340,7 +340,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_adpf_fdk.py
+++ b/v2.5.2/Scripts/process_g19_adpf_fdk.py
@@ -222,7 +222,7 @@ img_extent = (x.min(), x.max(), y.min(), y.max())
 # Use the Geostationary projection in cartopy
 ax = plt.axes([0, 0, 1, 1], projection=proj)
 
-ax.background_patch.set_fill(False)
+ax.patch.set_fill(False)
 # Add a background image
 #ax.stock_img()
 #fname = os.path.join(main_dir + '//Maps//', 'land_ocean_ice_8192.jpg')
@@ -252,7 +252,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=7)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)

--- a/v2.5.2/Scripts/process_g19_adpf_sec.py
+++ b/v2.5.2/Scripts/process_g19_adpf_sec.py
@@ -263,7 +263,7 @@ ax.set_extent([extent[0], extent[2], extent[1], extent[3]], ccrs.PlateCarree())
 # Define the image extent
 img_extent = [extent[0], extent[2], extent[1], extent[3]]
 
-ax.background_patch.set_fill(False)
+ax.patch.set_fill(False)
 # Add a background image
 #ax.stock_img()
 #fname = os.path.join(main_dir + '//Maps//', 'land_ocean_ice_8192.jpg')
@@ -297,7 +297,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)

--- a/v2.5.2/Scripts/process_g19_armrgb_fdk.py
+++ b/v2.5.2/Scripts/process_g19_armrgb_fdk.py
@@ -374,7 +374,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=5)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_armrgb_sec.py
+++ b/v2.5.2/Scripts/process_g19_armrgb_sec.py
@@ -383,7 +383,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_ashrgb_fdk.py
+++ b/v2.5.2/Scripts/process_g19_ashrgb_fdk.py
@@ -376,7 +376,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=5)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_ashrgb_sec.py
+++ b/v2.5.2/Scripts/process_g19_ashrgb_sec.py
@@ -385,7 +385,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_baseline_fdk.py
+++ b/v2.5.2/Scripts/process_g19_baseline_fdk.py
@@ -292,7 +292,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=7)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)

--- a/v2.5.2/Scripts/process_g19_baseline_sec.py
+++ b/v2.5.2/Scripts/process_g19_baseline_sec.py
@@ -362,7 +362,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)

--- a/v2.5.2/Scripts/process_g19_clprgb_fdk.py
+++ b/v2.5.2/Scripts/process_g19_clprgb_fdk.py
@@ -368,7 +368,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=5)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_clprgb_sec.py
+++ b/v2.5.2/Scripts/process_g19_clprgb_sec.py
@@ -363,7 +363,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_conrgb_fdk.py
+++ b/v2.5.2/Scripts/process_g19_conrgb_fdk.py
@@ -438,7 +438,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=5)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_conrgb_sec.py
+++ b/v2.5.2/Scripts/process_g19_conrgb_sec.py
@@ -446,7 +446,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_dccrgb_fdk.py
+++ b/v2.5.2/Scripts/process_g19_dccrgb_fdk.py
@@ -278,7 +278,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=5)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_dccrgb_sec.py
+++ b/v2.5.2/Scripts/process_g19_dccrgb_sec.py
@@ -290,7 +290,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_dcprgb_fdk.py
+++ b/v2.5.2/Scripts/process_g19_dcprgb_fdk.py
@@ -317,7 +317,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=5)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_dcprgb_sec.py
+++ b/v2.5.2/Scripts/process_g19_dcprgb_sec.py
@@ -328,7 +328,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_dlcrgb_fdk.py
+++ b/v2.5.2/Scripts/process_g19_dlcrgb_fdk.py
@@ -368,7 +368,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=5)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_dlcrgb_sec.py
+++ b/v2.5.2/Scripts/process_g19_dlcrgb_sec.py
@@ -363,7 +363,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_dlfrgb_fdk.py
+++ b/v2.5.2/Scripts/process_g19_dlfrgb_fdk.py
@@ -368,7 +368,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=5)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_dlfrgb_sec.py
+++ b/v2.5.2/Scripts/process_g19_dlfrgb_sec.py
@@ -363,7 +363,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_dmprgb_fdk.py
+++ b/v2.5.2/Scripts/process_g19_dmprgb_fdk.py
@@ -371,7 +371,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=5)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_dmprgb_sec.py
+++ b/v2.5.2/Scripts/process_g19_dmprgb_sec.py
@@ -366,7 +366,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_dmw_clouds_fdk.py
+++ b/v2.5.2/Scripts/process_g19_dmw_clouds_fdk.py
@@ -448,7 +448,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=10)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=11)

--- a/v2.5.2/Scripts/process_g19_dmw_clouds_sec.py
+++ b/v2.5.2/Scripts/process_g19_dmw_clouds_sec.py
@@ -458,7 +458,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=11)

--- a/v2.5.2/Scripts/process_g19_dsfrgb_fdk.py
+++ b/v2.5.2/Scripts/process_g19_dsfrgb_fdk.py
@@ -419,7 +419,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=5)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_dsfrgb_sec.py
+++ b/v2.5.2/Scripts/process_g19_dsfrgb_sec.py
@@ -413,7 +413,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_dsif_fdk.py
+++ b/v2.5.2/Scripts/process_g19_dsif_fdk.py
@@ -150,7 +150,7 @@ def procDsif(variable,product):
     ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=7)
 
     # Remove the outline border
-    ax.outline_patch.set_visible(False)
+    ax.spines['geo'].set_visible(False)
   
     # Add a title
     plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)

--- a/v2.5.2/Scripts/process_g19_dsif_sec.py
+++ b/v2.5.2/Scripts/process_g19_dsif_sec.py
@@ -180,7 +180,7 @@ def procDsif(variable,product):
     gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
     # Remove the outline border
-    ax.outline_patch.set_visible(False)
+    ax.spines['geo'].set_visible(False)
   
     # Add a title
     plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)

--- a/v2.5.2/Scripts/process_g19_dstrgb_fdk.py
+++ b/v2.5.2/Scripts/process_g19_dstrgb_fdk.py
@@ -376,7 +376,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=5)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_dstrgb_sec.py
+++ b/v2.5.2/Scripts/process_g19_dstrgb_sec.py
@@ -385,7 +385,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_dwvrgb_fdk.py
+++ b/v2.5.2/Scripts/process_g19_dwvrgb_fdk.py
@@ -278,7 +278,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=5)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_dwvrgb_sec.py
+++ b/v2.5.2/Scripts/process_g19_dwvrgb_sec.py
@@ -290,7 +290,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_fcorgb_fdk.py
+++ b/v2.5.2/Scripts/process_g19_fcorgb_fdk.py
@@ -366,7 +366,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=5)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_fcorgb_sec.py
+++ b/v2.5.2/Scripts/process_g19_fcorgb_sec.py
@@ -361,7 +361,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_fdfc_fdk.py
+++ b/v2.5.2/Scripts/process_g19_fdfc_fdk.py
@@ -233,7 +233,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=7)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False) 
+ax.spines['geo'].set_visible(False) 
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)

--- a/v2.5.2/Scripts/process_g19_fdfc_sec.py
+++ b/v2.5.2/Scripts/process_g19_fdfc_sec.py
@@ -246,7 +246,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False) 
+ax.spines['geo'].set_visible(False) 
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)

--- a/v2.5.2/Scripts/process_g19_ftprgb_fdk.py
+++ b/v2.5.2/Scripts/process_g19_ftprgb_fdk.py
@@ -367,7 +367,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=5)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_ftprgb_sec.py
+++ b/v2.5.2/Scripts/process_g19_ftprgb_sec.py
@@ -362,7 +362,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_glm_20s_fdk.py
+++ b/v2.5.2/Scripts/process_g19_glm_20s_fdk.py
@@ -158,7 +158,7 @@ ax.add_feature(cartopy.feature.BORDERS, edgecolor=plot_config["continents_color"
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=10)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
 
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=11)

--- a/v2.5.2/Scripts/process_g19_glm_20s_sec.py
+++ b/v2.5.2/Scripts/process_g19_glm_20s_sec.py
@@ -171,7 +171,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
 
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=11)

--- a/v2.5.2/Scripts/process_g19_glm_clouds_fdk.py
+++ b/v2.5.2/Scripts/process_g19_glm_clouds_fdk.py
@@ -264,7 +264,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=9)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 #---------------------------------------------------------------------------------------------
 #---------------------------------------------------------------------------------------------

--- a/v2.5.2/Scripts/process_g19_glm_clouds_sec.py
+++ b/v2.5.2/Scripts/process_g19_glm_clouds_sec.py
@@ -291,7 +291,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 #---------------------------------------------------------------------------------------------
 #---------------------------------------------------------------------------------------------

--- a/v2.5.2/Scripts/process_g19_glm_den_fdk.py
+++ b/v2.5.2/Scripts/process_g19_glm_den_fdk.py
@@ -309,7 +309,7 @@ if (seconds == '00'):
         ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=11)
 
         # Remove the outline border
-        ax.outline_patch.set_visible(False)
+        ax.spines['geo'].set_visible(False)
 
         # Add a title
         plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=12)

--- a/v2.5.2/Scripts/process_g19_glm_den_sec.py
+++ b/v2.5.2/Scripts/process_g19_glm_den_sec.py
@@ -319,7 +319,7 @@ if (seconds == '00'):
         gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
         # Remove the outline border
-        ax.outline_patch.set_visible(False)
+        ax.spines['geo'].set_visible(False)
 
         # Add a title
         plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=12)

--- a/v2.5.2/Scripts/process_g19_glm_hea_fdk.py
+++ b/v2.5.2/Scripts/process_g19_glm_hea_fdk.py
@@ -309,7 +309,7 @@ if (seconds == '00'):
         ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=11)
 
         # Remove the outline border
-        ax.outline_patch.set_visible(False)
+        ax.spines['geo'].set_visible(False)
 
         # Add a title
         plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=12)

--- a/v2.5.2/Scripts/process_g19_glm_hea_sec.py
+++ b/v2.5.2/Scripts/process_g19_glm_hea_sec.py
@@ -319,7 +319,7 @@ if (seconds == '00'):
         gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
         # Remove the outline border
-        ax.outline_patch.set_visible(False)
+        ax.spines['geo'].set_visible(False)
 
         # Add a title
         plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=12)

--- a/v2.5.2/Scripts/process_g19_glm_ir_20s_fdk.py
+++ b/v2.5.2/Scripts/process_g19_glm_ir_20s_fdk.py
@@ -222,7 +222,7 @@ ax.add_feature(cartopy.feature.BORDERS, edgecolor=plot_config["continents_color"
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=10)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
 
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=11)

--- a/v2.5.2/Scripts/process_g19_glm_ir_20s_sec.py
+++ b/v2.5.2/Scripts/process_g19_glm_ir_20s_sec.py
@@ -235,7 +235,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
 
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=11)

--- a/v2.5.2/Scripts/process_g19_glm_tra_fdk.py
+++ b/v2.5.2/Scripts/process_g19_glm_tra_fdk.py
@@ -433,7 +433,7 @@ if (seconds == '00'):
         ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=19)
 
         # Remove the outline border
-        ax.outline_patch.set_visible(False)
+        ax.spines['geo'].set_visible(False)
 
         # Add a title
         plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=20)

--- a/v2.5.2/Scripts/process_g19_glm_tra_sec.py
+++ b/v2.5.2/Scripts/process_g19_glm_tra_sec.py
@@ -440,7 +440,7 @@ if (seconds == '00'):
         gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
         # Remove the outline border
-        ax.outline_patch.set_visible(False)
+        ax.spines['geo'].set_visible(False)
 
         # Add a title
         plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=20)

--- a/v2.5.2/Scripts/process_g19_nmprgb_fdk.py
+++ b/v2.5.2/Scripts/process_g19_nmprgb_fdk.py
@@ -319,7 +319,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=5)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_nmprgb_sec.py
+++ b/v2.5.2/Scripts/process_g19_nmprgb_sec.py
@@ -330,7 +330,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_ntcrgb_fdk.py
+++ b/v2.5.2/Scripts/process_g19_ntcrgb_fdk.py
@@ -366,7 +366,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=5)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_ntcrgb_sec.py
+++ b/v2.5.2/Scripts/process_g19_ntcrgb_sec.py
@@ -361,7 +361,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_rad_fdk.py
+++ b/v2.5.2/Scripts/process_g19_rad_fdk.py
@@ -218,7 +218,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
 
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.), zorder=7))         

--- a/v2.5.2/Scripts/process_g19_rad_sec.py
+++ b/v2.5.2/Scripts/process_g19_rad_sec.py
@@ -223,7 +223,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
 
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.), zorder=7))         

--- a/v2.5.2/Scripts/process_g19_so2rgb_fdk.py
+++ b/v2.5.2/Scripts/process_g19_so2rgb_fdk.py
@@ -376,7 +376,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=5)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_so2rgb_sec.py
+++ b/v2.5.2/Scripts/process_g19_so2rgb_sec.py
@@ -385,7 +385,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_swvrgb_fdk.py
+++ b/v2.5.2/Scripts/process_g19_swvrgb_fdk.py
@@ -319,7 +319,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=5)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_swvrgb_sec.py
+++ b/v2.5.2/Scripts/process_g19_swvrgb_sec.py
@@ -330,7 +330,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_trurgb_fdk.py
+++ b/v2.5.2/Scripts/process_g19_trurgb_fdk.py
@@ -406,7 +406,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=5)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g19_trurgb_sec.py
+++ b/v2.5.2/Scripts/process_g19_trurgb_sec.py
@@ -404,7 +404,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g1X_b13_mosaic_sec.py
+++ b/v2.5.2/Scripts/process_g1X_b13_mosaic_sec.py
@@ -458,7 +458,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
 
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=7)

--- a/v2.5.2/Scripts/process_g1X_bands_fdk.py
+++ b/v2.5.2/Scripts/process_g1X_bands_fdk.py
@@ -230,7 +230,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=5)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g1X_bands_rad_fdk.py
+++ b/v2.5.2/Scripts/process_g1X_bands_rad_fdk.py
@@ -241,7 +241,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=5)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g1X_bands_rad_sec.py
+++ b/v2.5.2/Scripts/process_g1X_bands_rad_sec.py
@@ -266,7 +266,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g1X_bands_sec.py
+++ b/v2.5.2/Scripts/process_g1X_bands_sec.py
@@ -256,7 +256,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g1X_false_color_fdk.py
+++ b/v2.5.2/Scripts/process_g1X_false_color_fdk.py
@@ -428,7 +428,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=9)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=10)

--- a/v2.5.2/Scripts/process_g1X_false_color_sec.py
+++ b/v2.5.2/Scripts/process_g1X_false_color_sec.py
@@ -480,7 +480,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=10)

--- a/v2.5.2/Scripts/process_g1X_ir_clouds_enhance_fdk.py
+++ b/v2.5.2/Scripts/process_g1X_ir_clouds_enhance_fdk.py
@@ -216,7 +216,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=9)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
 
 #------------------------------------------------------------------------------------------------------
 #------------------------------------------------------------------------------------------------------

--- a/v2.5.2/Scripts/process_g1X_ir_clouds_enhance_sec.py
+++ b/v2.5.2/Scripts/process_g1X_ir_clouds_enhance_sec.py
@@ -239,7 +239,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=10)

--- a/v2.5.2/Scripts/process_g1X_ir_clouds_fdk.py
+++ b/v2.5.2/Scripts/process_g1X_ir_clouds_fdk.py
@@ -201,7 +201,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=9)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=10)

--- a/v2.5.2/Scripts/process_g1X_ir_clouds_sec.py
+++ b/v2.5.2/Scripts/process_g1X_ir_clouds_sec.py
@@ -225,7 +225,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=10)

--- a/v2.5.2/Scripts/process_g1X_sal_sec.py
+++ b/v2.5.2/Scripts/process_g1X_sal_sec.py
@@ -337,7 +337,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=11)

--- a/v2.5.2/Scripts/process_g1X_swd_fdk.py
+++ b/v2.5.2/Scripts/process_g1X_swd_fdk.py
@@ -243,7 +243,7 @@ ax.add_geometries(shapefile, ccrs.PlateCarree(), edgecolor=plot_config["continen
 ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=5)
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_g1X_swd_sec.py
+++ b/v2.5.2/Scripts/process_g1X_swd_sec.py
@@ -275,7 +275,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=6)

--- a/v2.5.2/Scripts/process_gcm_imagery_products.py
+++ b/v2.5.2/Scripts/process_gcm_imagery_products.py
@@ -408,7 +408,7 @@ def procGcom(product, start, lat_file, lon_file, var_file, width, height):
        ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=7)
 
        # Remove the outline border
-       ax.outline_patch.set_visible(False)
+       ax.spines['geo'].set_visible(False)
   
        # Add a title
        plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)

--- a/v2.5.2/Scripts/process_gfs_2mtemp_sec.py
+++ b/v2.5.2/Scripts/process_gfs_2mtemp_sec.py
@@ -206,7 +206,7 @@ for hour in range(hour_ini, hour_end, hour_inc):
         gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
     
         # Remove the outline border
-        ax.outline_patch.set_visible(False)
+        ax.spines['geo'].set_visible(False)
           
         # Add a title
         #plt.title("GFS (0.5°): 2 m Temperature (°C)", fontweight='bold', fontsize=7, loc='left')

--- a/v2.5.2/Scripts/process_gfs_accpre_sec.py
+++ b/v2.5.2/Scripts/process_gfs_accpre_sec.py
@@ -246,7 +246,7 @@ for hour in range(hour_ini, hour_end, hour_inc):
         gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
         # Remove the outline border
-        ax.outline_patch.set_visible(False)
+        ax.spines['geo'].set_visible(False)
           
         # Add a title
         #plt.title("GFS (0.5°): Total Precipitation", fontweight='bold', fontsize=7, loc='left')

--- a/v2.5.2/Scripts/process_gfs_gdindx_sec.py
+++ b/v2.5.2/Scripts/process_gfs_gdindx_sec.py
@@ -403,7 +403,7 @@ for hour in range(hour_ini, hour_end, hour_inc):
         gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
         
         # Remove the outline border
-        ax.outline_patch.set_visible(False)
+        ax.spines['geo'].set_visible(False)
           
         # Add a title
         #plt.title("GFS (0.5°): Galvez Davison Index (GDI)", fontweight='bold', fontsize=7, loc='left')

--- a/v2.5.2/Scripts/process_gfs_ghv500_sec.py
+++ b/v2.5.2/Scripts/process_gfs_ghv500_sec.py
@@ -231,7 +231,7 @@ for hour in range(hour_ini, hour_end, hour_inc):
         gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
         # Remove the outline border
-        ax.outline_patch.set_visible(False)
+        ax.spines['geo'].set_visible(False)
           
         # Add a title
         #plt.title("GFS (0.5°): Relative Vorticity (1 e-5 / s) + Geopotential Height (500 hPa)", fontweight='bold', fontsize=7, loc='left')

--- a/v2.5.2/Scripts/process_gfs_prtmsl_sec.py
+++ b/v2.5.2/Scripts/process_gfs_prtmsl_sec.py
@@ -238,7 +238,7 @@ for hour in range(hour_ini, hour_end, hour_inc):
         gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
         # Remove the outline border
-        ax.outline_patch.set_visible(False)
+        ax.spines['geo'].set_visible(False)
           
         # Add a title
         #plt.title("GFS (0.5°): PMSL + Winds (850 hPa)", fontweight='bold', fontsize=7, loc='left')

--- a/v2.5.2/Scripts/process_gfs_psgwrh_sec.py
+++ b/v2.5.2/Scripts/process_gfs_psgwrh_sec.py
@@ -427,7 +427,7 @@ for hour in range(hour_ini, hour_end, hour_inc):
         gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
         # Remove the outline border
-        ax.outline_patch.set_visible(False)
+        ax.spines['geo'].set_visible(False)
           
         # Add a title
         #plt.title("GFS (0.5°): PSML + Geop. Dif. (1000-850 hPa) + Winds (925 hPa) + Mean RH (1000~400 hPa)", fontweight='bold', fontsize=7, loc='left')

--- a/v2.5.2/Scripts/process_gfs_pwcape_sec.py
+++ b/v2.5.2/Scripts/process_gfs_pwcape_sec.py
@@ -245,7 +245,7 @@ for hour in range(hour_ini, hour_end, hour_inc):
         gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
         # Remove the outline border
-        ax.outline_patch.set_visible(False)
+        ax.spines['geo'].set_visible(False)
           
         # Add a title
         #plt.title("GFS (0.5°): Precipitable Water (mm) + CAPE (J/kg)", fontweight='bold', fontsize=7, loc='left')

--- a/v2.5.2/Scripts/process_gfs_pwcpth_sec.py
+++ b/v2.5.2/Scripts/process_gfs_pwcpth_sec.py
@@ -468,7 +468,7 @@ for hour in range(hour_ini, hour_end, hour_inc):
         gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
         # Remove the outline border
-        ax.outline_patch.set_visible(False)
+        ax.spines['geo'].set_visible(False)
           
         # Add a title
         #plt.title("GFS (0.5°): Total Precipitation", fontweight='bold', fontsize=7, loc='left')

--- a/v2.5.2/Scripts/process_gfs_sphcld_sec.py
+++ b/v2.5.2/Scripts/process_gfs_sphcld_sec.py
@@ -257,7 +257,7 @@ for hour in range(hour_ini, hour_end, hour_inc):
         gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
         # Remove the outline border
-        ax.outline_patch.set_visible(False)
+        ax.spines['geo'].set_visible(False)
           
         # Add a title
         #plt.title("GFS (0.5°): Relative Humidity at 800, 500, & 300mb or Low, Middle, & High Clouds", fontweight='bold', fontsize=7, loc='left')

--- a/v2.5.2/Scripts/process_gfs_wsd200_sec.py
+++ b/v2.5.2/Scripts/process_gfs_wsd200_sec.py
@@ -231,7 +231,7 @@ for hour in range(hour_ini, hour_end, hour_inc):
         gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
         # Remove the outline border
-        ax.outline_patch.set_visible(False)
+        ax.spines['geo'].set_visible(False)
           
         # Add a title
         #plt.title("GFS (0.5°): Wind Speed (kt) & Direction (200 hPa)", fontweight='bold', fontsize=7, loc='left')

--- a/v2.5.2/Scripts/process_gfs_wsd500_sec.py
+++ b/v2.5.2/Scripts/process_gfs_wsd500_sec.py
@@ -231,7 +231,7 @@ for hour in range(hour_ini, hour_end, hour_inc):
         gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
         # Remove the outline border
-        ax.outline_patch.set_visible(False)
+        ax.spines['geo'].set_visible(False)
           
         # Add a title
         #plt.title("GFS (0.5°): Wind Speed (kt) & Direction (500 hPa)", fontweight='bold', fontsize=7, loc='left')

--- a/v2.5.2/Scripts/process_gfs_wsd700_sec.py
+++ b/v2.5.2/Scripts/process_gfs_wsd700_sec.py
@@ -231,7 +231,7 @@ for hour in range(hour_ini, hour_end, hour_inc):
         gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
         # Remove the outline border
-        ax.outline_patch.set_visible(False)
+        ax.spines['geo'].set_visible(False)
           
         # Add a title
         #plt.title("GFS (0.5°): Wind Speed (kt) & Direction (700 hPa)", fontweight='bold', fontsize=7, loc='left')

--- a/v2.5.2/Scripts/process_gfs_wsd850_sec.py
+++ b/v2.5.2/Scripts/process_gfs_wsd850_sec.py
@@ -231,7 +231,7 @@ for hour in range(hour_ini, hour_end, hour_inc):
         gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
         # Remove the outline border
-        ax.outline_patch.set_visible(False)
+        ax.spines['geo'].set_visible(False)
           
         # Add a title
         #plt.title("GFS (0.5°): Wind Speed (kt) & Direction (850 hPa)", fontweight='bold', fontsize=7, loc='left')

--- a/v2.5.2/Scripts/process_ice.py
+++ b/v2.5.2/Scripts/process_ice.py
@@ -218,7 +218,7 @@ def procIce(product, time, lat_file, lon_file, var_file, nodata):
    ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=7)
 
    # Remove the outline border
-   ax.outline_patch.set_visible(False)
+   ax.spines['geo'].set_visible(False)
   
    # Add a title
    plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)

--- a/v2.5.2/Scripts/process_jps_alpwat_single_sec.py
+++ b/v2.5.2/Scripts/process_jps_alpwat_single_sec.py
@@ -4311,7 +4311,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " - Advected to " + date_formated, xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)

--- a/v2.5.2/Scripts/process_jps_btpw_v2.py
+++ b/v2.5.2/Scripts/process_jps_btpw_v2.py
@@ -205,7 +205,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)

--- a/v2.5.2/Scripts/process_jps_gblgvf_sec.py
+++ b/v2.5.2/Scripts/process_jps_gblgvf_sec.py
@@ -194,7 +194,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)    

--- a/v2.5.2/Scripts/process_jps_oceanc_sec.py
+++ b/v2.5.2/Scripts/process_jps_oceanc_sec.py
@@ -209,7 +209,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)    

--- a/v2.5.2/Scripts/process_jps_tstngl_sec.py
+++ b/v2.5.2/Scripts/process_jps_tstngl_sec.py
@@ -175,7 +175,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated, xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=9)

--- a/v2.5.2/Scripts/process_jps_tstnnh_sec.py
+++ b/v2.5.2/Scripts/process_jps_tstnnh_sec.py
@@ -176,7 +176,7 @@ gl.xlabels_top=False
 gl.ylabels_right=False
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated, xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=9)

--- a/v2.5.2/Scripts/process_jps_tstnsh_sec.py
+++ b/v2.5.2/Scripts/process_jps_tstnsh_sec.py
@@ -176,7 +176,7 @@ gl.xlabels_top=False
 gl.ylabels_right=False
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated, xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=9)

--- a/v2.5.2/Scripts/process_jps_vegidx_sec.py
+++ b/v2.5.2/Scripts/process_jps_vegidx_sec.py
@@ -219,7 +219,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)    

--- a/v2.5.2/Scripts/process_msg_bands_rgb_fdk.py
+++ b/v2.5.2/Scripts/process_msg_bands_rgb_fdk.py
@@ -202,7 +202,7 @@ def procMSG(data,product,type):
         ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=7)
 
         # Remove the outline border
-        ax.outline_patch.set_visible(False)
+        ax.spines['geo'].set_visible(False)
   
         # Add a title
         plt.annotate(plot_config["title_text"], xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)
@@ -331,7 +331,7 @@ def procMSG(data,product,type):
         ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=False, zorder=7)
 
         # Remove the outline border
-        ax.outline_patch.set_visible(False)
+        ax.spines['geo'].set_visible(False)
   
         # Add a title
         plt.annotate(plot_config["title_text"], xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)

--- a/v2.5.2/Scripts/process_msg_bands_rgb_sec.py
+++ b/v2.5.2/Scripts/process_msg_bands_rgb_sec.py
@@ -208,7 +208,7 @@ def procMSG(data,product,type):
         gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
         # Remove the outline border
-        ax.outline_patch.set_visible(False)
+        ax.spines['geo'].set_visible(False)
   
         # Add a title
         plt.annotate(plot_config["title_text"], xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)
@@ -342,7 +342,7 @@ def procMSG(data,product,type):
         gl = ax.gridlines(color=plot_config["grid_color"], alpha=0.5, linestyle='--', linewidth=plot_config["grid_width"], xlocs=np.arange(-180, 180, plot_config["grid_interval"]), ylocs=np.arange(-180, 180, plot_config["grid_interval"]), draw_labels=True, zorder=7)
 
         # Remove the outline border
-        ax.outline_patch.set_visible(False)
+        ax.spines['geo'].set_visible(False)
   
         # Add a title
         plt.annotate(plot_config["title_text"], xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)

--- a/v2.5.2/Scripts/process_mtp_gblsst_sec.py
+++ b/v2.5.2/Scripts/process_mtp_gblsst_sec.py
@@ -262,7 +262,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)    

--- a/v2.5.2/Scripts/process_sst_7dtrend_sec.py
+++ b/v2.5.2/Scripts/process_sst_7dtrend_sec.py
@@ -191,7 +191,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)    

--- a/v2.5.2/Scripts/process_sst_anomaly_sec.py
+++ b/v2.5.2/Scripts/process_sst_anomaly_sec.py
@@ -191,7 +191,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)    

--- a/v2.5.2/Scripts/process_sst_coralre_sec.py
+++ b/v2.5.2/Scripts/process_sst_coralre_sec.py
@@ -191,7 +191,7 @@ gl.ylabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'wei
 gl.xlabel_style = {'color': 'white', 'size': plot_config["cbar_labelsize"], 'weight': 'bold'}
 
 # Remove the outline border
-ax.outline_patch.set_visible(False)
+ax.spines['geo'].set_visible(False)
   
 # Add a title
 plt.annotate(plot_config["title_text"] + " " + date_formated , xy=(plot_config["title_x_offset"], plot_config["title_y_offset"]), xycoords='figure pixels', fontsize=plot_config["title_size"], fontweight='bold', color='white', bbox=dict(boxstyle="round",fc=(0.0, 0.0, 0.0), ec=(1., 1., 1.)), zorder=8)    

--- a/v2.5.2/Scripts/remap.py
+++ b/v2.5.2/Scripts/remap.py
@@ -46,7 +46,7 @@ def getGeoT(extent, nlines, ncols):
 def getScaleOffset(path, variable):
     nc = Dataset(path, mode='r')
     
-    if (variable == "BCM") or (variable == "Phase") or (variable == "Smoke") or (variable == "Dust") or (variable == "Mask") or (variable == "Power"): 
+    if (variable == "BCM") or (variable == "Phase") or (variable == "Smoke") or (variable == "Dust") or (variable == "Mask") or (variable == "Power") or (variable == "FSC"): 
         scale  = 1
         offset = 0     
     else:

--- a/v2.5.2/showcast_start_linux.sh
+++ b/v2.5.2/showcast_start_linux.sh
@@ -2,6 +2,10 @@
 # Select the number of SHOWCast parallel processes
 declare -i num_process=1
 
+# Configure geospatial library paths for GDAL/Cartopy
+export PROJ_LIB="$(pwd)/Miniconda3/envs/showcast/share/proj"
+export GDAL_DATA="$(pwd)/Miniconda3/envs/showcast/share/gdal"
+
 echo --------------
 echo "SHOWCast Start"
 echo --------------


### PR DESCRIPTION
## Summary
This PR fixes compatibility issues with modern versions of Cartopy (0.18+) and Matplotlib, along with bug fixes identified during testing.

## Changes

### 1. Replace deprecated Cartopy attributes (108 files)
- `ax.outline_patch.set_visible(False)` → `ax.spines['geo'].set_visible(False)`
- `ax.background_patch.set_fill(False)` → `ax.patch.set_fill(False)`
- These attributes were deprecated in Cartopy 0.18 and cause errors in newer versions

### 2. Add PROJ_LIB and GDAL_DATA environment variables
- Added export statements to `showcast_start_linux.sh`
- Resolves `PROJ: proj_create_from_database` errors in scripts using GDAL/Cartopy

### 3. Fix IndexError in html_update.py
- Added check for empty file list before accessing `files[-1]`
- Fixed incorrect variable `dst` → `thumb_dir` in copyfile call

### 4. Add .gitignore
- Ignores downloaded satellite data, output files, logs, and Python artifacts

## Testing
- Tested with Cartopy 0.22.0 and Matplotlib 3.9.4
- Verified processing scripts execute without deprecation warnings
- Confirmed fix prevents crashes on empty file lists

## Related Issues
None (fixes discovered during installation/testing)